### PR TITLE
Feature/sort upcoming stays

### DIFF
--- a/src/classes/Customer.js
+++ b/src/classes/Customer.js
@@ -11,13 +11,15 @@ class Customer {
   }
 
   getCustomerBookings(bookingInfo, currentDate) {
-    this.bookedStays = bookingInfo.filter((booking) => this.id === booking['userID']);
-    // this.upcomingStays = bookingInfo.bookings.filter((booking) => {
-    //   if (this.id === booking['userID'] && booking['date'] > currentDate) {
-    //     return booking;
-    //   };
-    // });
-    // console.log('upcomingStays',this.upcomingStays)
+    this.upcomingStays = bookingInfo.filter((booking) => {
+      if (this.id === booking.userID && parseInt(booking.date) >= currentDate) {
+        return booking;
+
+      } else if (this.id === booking.userID && parseInt(booking.date) < currentDate) {
+        this.pastStays.push(booking);
+        return
+      };
+    });
   };
 
   calculateTotalSpent(roomInfo) {

--- a/src/classes/Customer.js
+++ b/src/classes/Customer.js
@@ -2,7 +2,7 @@ class Customer {
   constructor(customerInfo, bookingInfo, roomInfo, currentDate) {
     this.id = customerInfo.id;
     this.name = customerInfo.name;
-    this.bookedStays = [];
+    this.bookedStays = bookingInfo;
     this.pastStays = [];
     this.upcomingStays = [];
     this.retrieveBookings = this.getCustomerBookings(bookingInfo, currentDate);
@@ -32,10 +32,6 @@ class Customer {
       return Math.round(num * 100)/100;
     }, 0);
   };
-
-  // filterUpcomingStays() {
-  //
-  // };
 };
 
 export default Customer;

--- a/src/classes/Customer.js
+++ b/src/classes/Customer.js
@@ -18,7 +18,7 @@ class Customer {
       this.bookedStays.forEach((stay) => {
         if (room.number === stay.roomNumber) {
           num += room.costPerNight;
-        }
+        };
       });
       return Math.round(num * 100)/100;
     }, 0);

--- a/src/classes/Customer.js
+++ b/src/classes/Customer.js
@@ -1,20 +1,27 @@
 class Customer {
-  constructor(customerInfo, bookingInfo, roomInfo) {
+  constructor(customerInfo, bookingInfo, roomInfo, currentDate) {
     this.id = customerInfo.id;
     this.name = customerInfo.name;
     this.bookedStays = [];
-    this.retrieveBookings = this.filterCustomerBookings(bookingInfo);
+    this.pastStays = [];
+    this.upcomingStays = [];
+    this.retrieveBookings = this.getCustomerBookings(bookingInfo, currentDate);
     this.totalSpent = 0;
     this.retrieveTotalSpent = this.calculateTotalSpent(roomInfo);
-    // this.userName = `customer${this.id}`;
-    // this.password = 'overlook2021';
   }
-  filterCustomerBookings(bookingInfo) {
-    this.bookedStays = bookingInfo.bookings.filter((booking) => this.id === booking['userID']);
+
+  getCustomerBookings(bookingInfo, currentDate) {
+    this.bookedStays = bookingInfo.filter((booking) => this.id === booking['userID']);
+    // this.upcomingStays = bookingInfo.bookings.filter((booking) => {
+    //   if (this.id === booking['userID'] && booking['date'] > currentDate) {
+    //     return booking;
+    //   };
+    // });
+    // console.log('upcomingStays',this.upcomingStays)
   };
 
   calculateTotalSpent(roomInfo) {
-    this.totalSpent = roomInfo.rooms.reduce((num, room) => {
+    this.totalSpent = roomInfo.reduce((num, room) => {
       this.bookedStays.forEach((stay) => {
         if (room.number === stay.roomNumber) {
           num += room.costPerNight;
@@ -23,6 +30,10 @@ class Customer {
       return Math.round(num * 100)/100;
     }, 0);
   };
+
+  // filterUpcomingStays() {
+  //
+  // };
 };
 
 export default Customer;

--- a/src/classes/Customer.js
+++ b/src/classes/Customer.js
@@ -2,15 +2,18 @@ class Customer {
   constructor(customerInfo, bookingInfo, roomInfo, currentDate) {
     this.id = customerInfo.id;
     this.name = customerInfo.name;
-    this.bookedStays = bookingInfo;
+    this.allBookedStays = [];
     this.pastStays = [];
     this.upcomingStays = [];
     this.retrieveBookings = this.getCustomerBookings(bookingInfo, currentDate);
     this.totalSpent = 0;
     this.retrieveTotalSpent = this.calculateTotalSpent(roomInfo);
+    this.reformatDate = this.reformatDate();
   }
 
   getCustomerBookings(bookingInfo, currentDate) {
+    this.allBookedStays = bookingInfo.filter((booking) => this.id === booking.userID);
+
     this.upcomingStays = bookingInfo.filter((booking) => {
       if (this.id === booking.userID && parseInt(booking.date) >= currentDate) {
         return booking;
@@ -24,13 +27,29 @@ class Customer {
 
   calculateTotalSpent(roomInfo) {
     this.totalSpent = roomInfo.reduce((num, room) => {
-      this.bookedStays.forEach((stay) => {
+      this.allBookedStays.forEach((stay) => {
         if (room.number === stay.roomNumber) {
           num += room.costPerNight;
         };
       });
       return Math.round(num * 100)/100;
     }, 0);
+  };
+
+  reformatDate() {
+    let formattedStays = [];
+    let dash = '/';
+    let position1 = 4;
+    let position2 = 7;
+
+    this.upcomingStays.forEach((stay) => {
+      let result1 = [stay.date.slice(0, position1), dash, stay.date.slice(position1)].join('');
+      let result2 = [result1.slice(0, position2), dash, result1.slice(position2)].join('');
+      stay.date = result2;
+      formattedStays.push(stay);
+    });
+
+    this.upcomingStays = formattedStays;
   };
 };
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -13,7 +13,7 @@ let domUpdates = {
     gridContainer.innerHTML = ``;
     roomDisplayHeading.innerText = 'Upcoming Stays';
 
-    customer.bookedStays.forEach((stay) => {
+    customer.upcomingStays.forEach((stay) => {
       gridContainer.innerHTML += `
         <section class="grid-item" tabindex="0" name="upcoming-stay" id="${stay.id}">
           <p>Date of Stay: ${stay.date}</p>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -113,8 +113,6 @@ function organizeData(data, apiCustomerInfo) {
 function instantiateClasses(customerInfo, roomInfo, bookingInfo) {
   let currentDate = getCurrentDate();
 
-  customer = new Customer(customerInfo, bookingInfo, roomInfo, currentDate);
-
   let instantiatedRooms = [];
   roomInfo.rooms.forEach((rm) => {
     let room = new Rooms(rm);
@@ -127,6 +125,7 @@ function instantiateClasses(customerInfo, roomInfo, bookingInfo) {
     instantiatedBookings.push(booking)
   });
 
+  customer = new Customer(customerInfo, instantiatedBookings, instantiatedRooms, currentDate);
   hotel = new Hotel(instantiatedBookings, instantiatedRooms);
 };
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -136,7 +136,7 @@ function getCurrentDate() {
   let month = String(date.getMonth()+1).padStart(2, "0");
 
   let completeDate = `${year}${month}${day}`;
-  return completeDate.toString();
+  return parseInt(completeDate);
 };
 
 function initializeData(customerInfo, roomInfo, bookingInfo) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -111,7 +111,9 @@ function organizeData(data, apiCustomerInfo) {
 
 // Create Objects/ Data Model
 function instantiateClasses(customerInfo, roomInfo, bookingInfo) {
-  customer = new Customer(customerInfo, bookingInfo, roomInfo);
+  let currentDate = getCurrentDate();
+
+  customer = new Customer(customerInfo, bookingInfo, roomInfo, currentDate);
 
   let instantiatedRooms = [];
   roomInfo.rooms.forEach((rm) => {
@@ -128,6 +130,15 @@ function instantiateClasses(customerInfo, roomInfo, bookingInfo) {
   hotel = new Hotel(instantiatedBookings, instantiatedRooms);
 };
 
+function getCurrentDate() {
+  let date = new Date()
+  let day = date.getDate();
+  let year = date.getFullYear();
+  let month = String(date.getMonth()+1).padStart(2, "0");
+
+  let completeDate = `${year}${month}${day}`;
+  return completeDate.toString();
+};
 
 function initializeData(customerInfo, roomInfo, bookingInfo) {
   separatedData = [customerInfo, roomInfo, bookingInfo];

--- a/test/Hotel-test.js
+++ b/test/Hotel-test.js
@@ -1751,4 +1751,6 @@ roomNumber: 3
 
     expect(hotel.filterByRoomType(type)).to.equal(`There are no suite's available for the dates selected`)
   });
+
+  
 });


### PR DESCRIPTION
## Description

Please include a summary of the change and/or functionality implementation:
This pull request creates functions in the Customer class that will get and sort the customers past and upcoming stays.  Now under the upcoming stays it only shows stays that are booked for the current date or later.  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] open index.html
- [x] dev tools
- [x] terminal

## Checklist:

- [x] I have performed a self-review of my own code
- [x] No console error messages

## Additional info
Please include any other relevant information here:
It also will reformat the date of the bookings once they have been instantiated and matched.  This makes it more appealing to look at on the page.