### PR TITLE
Create fcn to decide stay type before populating

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -58,7 +58,8 @@
         <h2 class="upcoming-stays " id="roomDisplayHeading">Upcoming Stays</h2>
         <div class="room-navigation-buttons">
           <button class="room-nav-btn hidden" type="button" name="back-to-results" id="backToResults">Back to Results</button>
-          <button class="room-nav-btn hidden" type="button" name="upcoming-stays-button" id="upcomingStaysBtn">My Upcoming Stays</button>
+          <button class="room-nav-btn hidden" type="button" name="upcoming-stays-button" id="upcomingStaysBtn">View Upcoming Stays</button>
+          <button class="room-nav-btn hidden" type="button" name="past-stays-button" id="pastStaysBtn">View Past Stays</button>
         </div>
       </div>
       <article class="room-display-area hidden" id="roomDisplayArea">

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -7,20 +7,24 @@ export const allCustomersPromise = () => {
   .then(response => response.json())
 };
 
+
 export const singleCustomerPromise = (customerUsername) => {
   return fetch(`http://localhost:3001/api/v1/customers/${customerUsername}`)
   .then(response => response.json())
 };
+
 
 export const roomPromise = () => {
   return fetch('http://localhost:3001/api/v1/rooms')
   .then(response => response.json())
 };
 
+
 export const bookingsPromise = () => {
   return fetch('http://localhost:3001/api/v1/bookings')
   .then(response => response.json())
 };
+
 
 export const bookUserStay = (newStay, event) => {
   fetch('http://localhost:3001/api/v1/bookings', {

--- a/src/classes/Bookings.js
+++ b/src/classes/Bookings.js
@@ -1,7 +1,3 @@
-// import Hotel from '/src/classes/Hotel.js';
-// import Rooms from '/src/classes/Rooms.js';
-// import domUpdates from '../src/domUpdates.js';
-
 class Bookings {
   constructor(bookedStay) {
     this.id = bookedStay.id;

--- a/src/classes/Customer.js
+++ b/src/classes/Customer.js
@@ -8,22 +8,22 @@ class Customer {
     this.retrieveBookings = this.getCustomerBookings(bookingInfo, currentDate);
     this.totalSpent = 0;
     this.retrieveTotalSpent = this.calculateTotalSpent(roomInfo);
-    this.reformatDate = this.reformatDate();
+    // this.reformatDate = this.reformatDate();
   }
 
   getCustomerBookings(bookingInfo, currentDate) {
     this.allBookedStays = bookingInfo.filter((booking) => this.id === booking.userID);
 
-    this.upcomingStays = bookingInfo.filter((booking) => {
-      if (this.id === booking.userID && parseInt(booking.date) >= currentDate) {
-        return booking;
+    this.allBookedStays.forEach((booking) => {
+      if (parseInt(booking.date) >= currentDate) {
+        this.upcomingStays.push(booking);
 
-      } else if (this.id === booking.userID && parseInt(booking.date) < currentDate) {
+      } else if (parseInt(booking.date) < currentDate){
         this.pastStays.push(booking);
-        return
       };
     });
   };
+
 
   calculateTotalSpent(roomInfo) {
     this.totalSpent = roomInfo.reduce((num, room) => {
@@ -36,21 +36,22 @@ class Customer {
     }, 0);
   };
 
-  reformatDate() {
-    let formattedStays = [];
-    let dash = '/';
-    let position1 = 4;
-    let position2 = 7;
 
-    this.upcomingStays.forEach((stay) => {
-      let result1 = [stay.date.slice(0, position1), dash, stay.date.slice(position1)].join('');
-      let result2 = [result1.slice(0, position2), dash, result1.slice(position2)].join('');
-      stay.date = result2;
-      formattedStays.push(stay);
-    });
-
-    this.upcomingStays = formattedStays;
-  };
+  // reformatDate() {
+  //   let formattedStays = [];
+  //   let dash = '/';
+  //   let position1 = 4;
+  //   let position2 = 7;
+  //
+  //   this.upcomingStays.forEach((stay) => {
+  //     let result1 = [stay.date.slice(0, position1), dash, stay.date.slice(position1)].join('');
+  //     let result2 = [result1.slice(0, position2), dash, result1.slice(position2)].join('');
+  //     stay.date = result2;
+  //     formattedStays.push(stay);
+  //   });
+  //
+  //   this.upcomingStays = formattedStays;
+  // };
 };
 
 export default Customer;

--- a/src/classes/Hotel.js
+++ b/src/classes/Hotel.js
@@ -1,6 +1,5 @@
 import domUpdates from '/src/domUpdates.js';
-// import Bookings from './src/classes/Bookings.js';
-// import Rooms from './src/classes/Rooms.js';
+
 
 class Hotel {
   constructor(instantiatedBookings, instantiatedRooms) {
@@ -9,7 +8,8 @@ class Hotel {
     this.roomAvailability = instantiatedRooms;
   };
 
-  filterAvailableRooms(checkinDate, checkoutDate, roomType, gridContainer, roomDisplayHeading, upcomingStaysBtn, noResultsMsg) {
+
+  filterAvailableRooms(checkinDate, checkoutDate, roomType, gridContainer, roomDisplayHeading, upcomingStaysBtn, noResultsMsg, dateError, pastStaysBtn) {
     if (!checkinDate.value || !checkoutDate.value) {
       return domUpdates.show(dateError);
     };
@@ -30,19 +30,19 @@ class Hotel {
     });
 
     if (roomType !== 'all-room-types') {
-      return this.filterByRoomType(roomType, noResultsMsg, gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError);
+      return this.filterByRoomType(roomType, noResultsMsg, gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError, pastStaysBtn);
     };
-      domUpdates.populateFilteredRooms(this.roomAvailability, gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError);
+      domUpdates.populateFilteredRooms(this.roomAvailability, gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError, pastStaysBtn);
   };
 
 
-  filterByRoomType(type, noResultsMsg, gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError) {
+  filterByRoomType(type, noResultsMsg, gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError, pastStaysBtn) {
     let availableTypes = this.roomAvailability.filter((room) => room.roomType === type);
 
     if (!availableTypes.length) {
       return domUpdates.show(noResultsMsg);
     };
-    domUpdates.populateFilteredRooms(availableTypes,  gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError);
+    domUpdates.populateFilteredRooms(availableTypes,  gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError, pastStaysBtn);
   };
 };
 

--- a/src/classes/Rooms.js
+++ b/src/classes/Rooms.js
@@ -1,5 +1,3 @@
-// import Customer from './src/classes/Customer'
-
 class Rooms {
   constructor(roomInfo) {
     this.number = roomInfo.number;

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -9,19 +9,38 @@ let domUpdates = {
     userTotalSpent.innerText = `Total Spent: ${customer.totalSpent}`;
   },
 
-  populateUpcomingStays(customer) {
-    gridContainer.innerHTML = ``;
-    roomDisplayHeading.innerText = 'Upcoming Stays';
 
-    customer.upcomingStays.forEach((stay) => {
+  determineTypeOfStay(customer, pastStaysBtn, upcomingStaysBtn, event) {
+    if (event === undefined || event.target.id !== 'pastStaysBtn') {
+      domUpdates.show(pastStaysBtn);
+      domUpdates.hide(upcomingStaysBtn);
+      gridContainer.innerHTML = ``;
+      roomDisplayHeading.innerText = 'Upcoming Stays';
+      let stayType = customer.upcomingStays;
+      domUpdates.populateUpcomingStays(stayType);
+
+    }else if (event.target.id === 'pastStaysBtn') {
+      domUpdates.hide(pastStaysBtn);
+      domUpdates.show(upcomingStaysBtn);
+      gridContainer.innerHTML = ``;
+      roomDisplayHeading.innerText = 'Past Stays';
+      let stayType = customer.pastStays;
+      domUpdates.populateUpcomingStays(stayType);
+    };
+  },
+
+
+  populateUpcomingStays(stayType) {
+    stayType.forEach((stay) => {
       gridContainer.innerHTML += `
         <section class="grid-item" tabindex="0" name="upcoming-stay" id="${stay.id}">
           <p>Date of Stay: ${stay.date}</p>
           <p>Room: ${stay.roomNumber}</p>
         </section>
       `;
-    })
+    });
   },
+
 
   populateRoomTypeDropDwn(roomInfo) {
     let filteredRoomTypes = roomInfo.rooms.reduce((arr, room) => {
@@ -38,8 +57,10 @@ let domUpdates = {
     });
   },
 
-  populateFilteredRooms(roomsToDisplay, gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError) {
+
+  populateFilteredRooms(roomsToDisplay, gridContainer, roomDisplayHeading, upcomingStaysBtn, dateError, pastStaysBtn) {
     domUpdates.hide(dateError);
+    domUpdates.hide(pastStaysBtn);
     domUpdates.show(upcomingStaysBtn);
     roomDisplayHeading.innerText = 'Available Rooms';
     gridContainer.innerHTML = '';
@@ -61,6 +82,7 @@ let domUpdates = {
       `;
     });
   },
+
 
   populateIndividualRoom(roomId, gridContainer, indRoom, allRooms, backToResults) {
     domUpdates.hide(gridContainer);
@@ -84,9 +106,11 @@ let domUpdates = {
     });
   },
 
+
   show(element) {
     element.classList.remove('hidden');
   },
+
 
   hide(element) {
     element.classList.add('hidden');


### PR DESCRIPTION
## Description

Please include a summary of the change and/or functionality implementation:
This pull request filters the bookings and stores them in the Customer class as pastStays and upcomingStays.  Before populating it goes to a fcn that decides which stay type should be populated on the page.  I also fixed the button bugs so they are appearing at the correct time.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] open index.html
- [x] dev tools
- [x] terminal

## Checklist:

- [x] I have performed a self-review of my own code
- [x] No console error messages

## Additional info
Please include any other relevant information here:
